### PR TITLE
Issue 2: Fix deprecated notice (reboot)

### DIFF
--- a/includes/viewer.php
+++ b/includes/viewer.php
@@ -47,7 +47,7 @@ class Send_System_Info_Viewer {
 
 		echo '<pre>';
 		if ( $query_value == $value ) {
-			echo Send_System_Info_Plugin::display();
+			echo esc_html( Send_System_Info_Plugin::display() );
 			exit();
 		} else {
 			exit( 'Invalid System Info URL.' );

--- a/send-system-info.php
+++ b/send-system-info.php
@@ -3,7 +3,7 @@
  * Plugin Name: Send System Info
  * Plugin URI: http://johnregan3.github.io/send-system-info
  * Description: Displays System Info for debugging.  This info can be emailed and/or displayed to support personnel via unique URL.
- * Version: 1.0
+ * Version: 1.1
  * Author: johnregan3
  * Author URI: http://johnregan3.me
  * License: GPLv2+

--- a/views/send-system-info.php
+++ b/views/send-system-info.php
@@ -11,7 +11,7 @@
 				<div>
 					<textarea readonly="readonly" onclick="this.focus();this.select()" id="ssi-textarea" name="send-system-info-textarea" title="<?php _e( 'To copy the System Info, click below then press Ctrl + C (PC) or Cmd + C (Mac).', 'send-system-info' ); ?>">
 <?php //Non standard indentation needed for plain-text display ?>
-<?php echo self::display() ?>
+<?php echo esc_html( self::display() ) ?>
 					</textarea>
 				</div>
 				<p class="submit">


### PR DESCRIPTION
This includes a check for whether mysqli should be used.

This issue centres on the fact that PHP deprecated mysql functions in favour of mysqli, in version 5.5.

The `$wpdb` class does a check for the version, and sets the `use_mysqli` var accordingly. Therefore we can say that if `use_mysqli` is false, PHP is older than 5.5, and we shouldn't see a deprecated notice.

Further, if `use_mysqli` is true, then the `dbh` variable is set to a link that can be used by functions like `mysqli_get_server_info`.

Finally, I also included an `@` before each server_info function, so at the very least they return `''` instead of a notice.
