### PR TITLE
php 7 undefined notice

### DIFF
--- a/includes/browser.php
+++ b/includes/browser.php
@@ -217,7 +217,7 @@
 
 		public $OPERATING_SYSTEM_UNKNOWN = 'unknown';
 
-		function Browser($useragent="") {
+		function __construct($useragent="") {
 			$this->reset();
 			if( $useragent != "" ) {
 				$this->setUserAgent($useragent);


### PR DESCRIPTION
use __construct to avoid deprecated notices